### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://agnihotrik10.visualstudio.com/3798e991-fa11-4244-b329-4e43b8008c3f/1d39e391-5fd9-4b93-b0bd-86dbef99c108/_apis/work/boardbadge/a2e4b1e6-42d5-4df9-9da5-669515e1ee30)](https://agnihotrik10.visualstudio.com/3798e991-fa11-4244-b329-4e43b8008c3f/_boards/board/t/1d39e391-5fd9-4b93-b0bd-86dbef99c108/Microsoft.RequirementCategory)
 
 
 # agnihotriketan.github.io


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#351](https://agnihotrik10.visualstudio.com/3798e991-fa11-4244-b329-4e43b8008c3f/_workitems/edit/351). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.